### PR TITLE
Transfer to Simple Icons

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 LitoMore
+Copyright (c) 2022 Simple Icons Collaborators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple Icons CDN
 ## Usage
 
 ```
-GET https://si-cdn.vercel.app/:icon_slug/:color?
+GET https://cdn.simpleicons.org/:icon_slug/:color?
 ```
 
 ### Parameters
@@ -20,17 +20,16 @@ Optional. Default to the color of icon from [Simple Icons](https://simpleicons.o
 
 ### Example
 
-- <picture><source media="(prefers-color-scheme: dark)" srcset="https://si-cdn.vercel.app/simpleicons/eee"><source media="(prefers-color-scheme: light)" srcset="https://si-cdn.vercel.app/simpleicons"><img height="14" src="https://si-cdn.vercel.app/simpleicons"/></picture> - https://si-cdn.vercel.app/simpleicons
-- <img height="14" src="https://si-cdn.vercel.app/simpleicons/blue"/> - https://si-cdn.vercel.app/simpleicons/blue
-- <img height="14" src="https://si-cdn.vercel.app/simpleicons/hotpink"/> - https://si-cdn.vercel.app/simpleicons/hotpink
-- <img height="14" src="https://si-cdn.vercel.app/simpleicons/0cf"/> - https://si-cdn.vercel.app/simpleicons/0cf
-- <img height="14" src="https://si-cdn.vercel.app/simpleicons/00ccff"/> - https://si-cdn.vercel.app/simpleicons/00ccff
-- <img height="14" src="https://si-cdn.vercel.app/simpleicons/00ccff99"/> - https://si-cdn.vercel.app/simpleicons/00ccff99
+- <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/simpleicons/eee"><source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/simpleicons"><img height="14" src="https://cdn.simpleicons.org/simpleicons"/></picture> - https://cdn.simpleicons.org/simpleicons
+- <img height="14" src="https://cdn.simpleicons.org/simpleicons/blue"/> - https://cdn.simpleicons.org/simpleicons/blue
+- <img height="14" src="https://cdn.simpleicons.org/simpleicons/hotpink"/> - https://cdn.simpleicons.org/simpleicons/hotpink
+- <img height="14" src="https://cdn.simpleicons.org/simpleicons/0cf"/> - https://cdn.simpleicons.org/simpleicons/0cf
+- <img height="14" src="https://cdn.simpleicons.org/simpleicons/00ccff"/> - https://cdn.simpleicons.org/simpleicons/00ccff
+- <img height="14" src="https://cdn.simpleicons.org/simpleicons/00ccff99"/> - https://cdn.simpleicons.org/simpleicons/00ccff99
 
 ### Domain aliases
 
-- si-cdn.vercel.app
-- si-cdn.now.sh
+- cdn.simpleicons.org
 - icons.ly (using Cloudflare DNS)
 
 ## License

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LitoMore/simple-icons-cdn.git"
+    "url": "git+https://github.com/simple-icons/simple-icons-cdn.git"
   },
   "keywords": [
     "simple-icons",
@@ -22,12 +22,12 @@
     "brands",
     "logos"
   ],
-  "author": "LitoMore",
+  "author": "Simple Icons Collaborators",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/LitoMore/simple-icons-cdn/issues"
+    "url": "https://github.com/simple-icons/simple-icons-cdn/issues"
   },
-  "homepage": "https://github.com/LitoMore/simple-icons-cdn#readme",
+  "homepage": "https://github.com/simple-icons/simple-icons-cdn#readme",
   "dependencies": {
     "my-way": "^2.0.0",
     "simple-icons": "^7.17.0"

--- a/source/app.ts
+++ b/source/app.ts
@@ -25,7 +25,7 @@ const app = (request: VercelRequest, response: VercelResponse) => {
 	}
 
 	if (requestUrl === '/') {
-		return response.redirect(308, 'https://github.com/LitoMore/simple-icons-cdn');
+		return response.redirect(308, 'https://github.com/simple-icons/simple-icons-cdn');
 	}
 
 	return response.status(404).send({status: 404});


### PR DESCRIPTION
The Vercel app will still be under my account.

I checked the pricing plans at Vercel. It costs $20/mo per member for the team plan. But I think the current free plan is enough to use. We could consider the team plan later.

Seems it does not support transfer to another user directly on Vercel. But I think it can be transferred to a temporary team, then transferred to you, if you want the ownership of this project.